### PR TITLE
Improve renovate bot

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -10,5 +10,6 @@
       "allowBranch": "master"
     }
   },
-  "version": "0.3.3"
+  "version": "0.3.3",
+  "hoist": true
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "postinstall": "check-node-version --package",
-    "bootstrap": "lerna bootstrap --hoist --ci",
+    "bootstrap": "lerna bootstrap --ci",
     "clean": "lerna clean",
     "build": "lerna run build --concurrency 4",
     "test": "run-s test:build test:lint test:jest test:sol",

--- a/renovate.json
+++ b/renovate.json
@@ -15,9 +15,6 @@
   "minor": {
     "groupName": "all dependencies"
   },
-  "lockFileMaintenance": {
-    "enabled": true
-  },
   "schedule": "before 9am on Wednesday",
   "timezone": "Asia/Tokyo"
 }


### PR DESCRIPTION
- Enabled `hoist` in lerna.json for renovate-bot to hoist
- When renovate-bot sends pull request of patch/minor version up, lockfile update at the same time. Therefore, maintenance of lockfile is unnecessary.