### PR TITLE
bugfix: no increase nonce

### DIFF
--- a/packages/easy-client/src/adapter.ts
+++ b/packages/easy-client/src/adapter.ts
@@ -19,7 +19,7 @@ export function adapter (signer: Signer, api: Api): (config: RequestConfig) => A
 
     // sign and async response
     // method
-    config.method = config.method!.toUpperCase() || 'GET'
+    config.method = (config.method && config.method.toUpperCase()) || 'GET'
 
     // params
     const url = new URL(config.url!)

--- a/packages/easy-client/src/adapter.ts
+++ b/packages/easy-client/src/adapter.ts
@@ -19,7 +19,7 @@ export function adapter (signer: Signer, api: Api): (config: RequestConfig) => A
 
     // sign and async response
     // method
-    config.method = config.method || 'GET'
+    config.method = config.method!.toUpperCase() || 'GET'
 
     // params
     const url = new URL(config.url!)


### PR DESCRIPTION
A string of upper case and a string of lower case of a hash value are different.  Therefore, only use HTTP method of upper case in easy-client.
ref: https://github.com/uniqys/UniqysKit/pull/20/files#r289666553