### PR TITLE
Support Execution on Windows

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,7 +17,9 @@ strategy:
     MacOS_Node10.9.0:
       nodeVersion: '10.9.0'
       os: 'macos-10.14'
-
+    Windows_Node10.9.0:
+      nodeVersion: '10.9.0'
+      os: 'vs2017-win2016'
 pool:
   vmImage: $(os)
 
@@ -29,9 +31,12 @@ steps:
 
 - script: |
     npm ci
-    npm run build
-  displayName: 'npm install and build'
+  displayName: 'npm ci'
 
 - script: |
-    npm run test
-  displayName: 'exec test'
+    npm run build
+  displayName: 'npm run build'
+
+- script: |
+    npm test
+  displayName: 'npm test'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,7 +3,8 @@
 # Add steps that analyze code, save build artifacts, deploy, and more:
 # https://docs.microsoft.com/azure/devops/pipelines/languages/javascript
 
-trigger: none
+trigger:
+- master
 
 pr:
 - master

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,6 +3,11 @@
 # Add steps that analyze code, save build artifacts, deploy, and more:
 # https://docs.microsoft.com/azure/devops/pipelines/languages/javascript
 
+trigger: none
+
+pr:
+- master
+
 strategy:
   matrix:
     Linux_Node10.9.0:

--- a/package-lock.json
+++ b/package-lock.json
@@ -12923,6 +12923,11 @@
         "aproba": "^1.1.1"
       }
     },
+    "run-script-os": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/run-script-os/-/run-script-os-1.0.7.tgz",
+      "integrity": "sha512-H4NAhP9PiseQQm3Vpen7CHksfKGqC4dmwoVu/9th97r3XyBrMtkg4jIUiy/8dgzuI9MGwmK/7vf13Wncx+Y4bw=="
+    },
     "rustbn.js": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/rustbn.js/-/rustbn.js-0.2.0.tgz",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -21,7 +21,9 @@
     "gen-schema:key": "typescript-json-schema tsconfig.build.json KeySchema --include src/config/key.ts --out src/config/schema/key.json --required",
     "build": "run-s build:ts build:copy",
     "build:ts": "tsc -p tsconfig.build.json",
-    "build:copy": "mkdir -p ./dist/config/schema && run-for-every-file --src ./src/config/schema/ --file '*.json' --run 'cp ./src/config/schema/{{file-name}}.json ./dist/config/schema/'",
+    "build:copy": "run-script-os",
+    "build:copy:darwin:linux": "mkdir -p ./dist/config/schema && run-for-every-file --src ./src/config/schema/ --file '*.json' --run 'cp ./src/config/schema/{{file-name}}.json ./dist/config/schema/'",
+    "build:copy:win32": "del .\\dist\\config\\schema && md .\\dist\\config\\schema && copy .\\src\\config\\schema\\*.json .\\dist\\config\\schema\\'",
     "lint": "tslint -c tslint.json -p tsconfig.json",
     "test": "run-s test:build test:lint",
     "test:build": "tsc -p tsconfig.json --noEmit",
@@ -47,6 +49,7 @@
     "@uniqys/type-definitions": "^0.3.0",
     "npm-run-all": "^4.1.5",
     "run-for-every-file": "^1.1.0",
+    "run-script-os": "^1.0.7",
     "tslint": "^5.11.0",
     "typescript": "^3.0.3",
     "typescript-json-schema": "^0.38.0"

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -79,7 +79,8 @@ const command: CommandModule = {
         'EASY_MEMCACHED_HOST': memcachedInfo.address,
         'EASY_MEMCACHED_PORT': memcachedInfo.port.toString()
       }),
-      stdio: 'inherit'
+      stdio: 'inherit',
+      shell: true
     })
     process.on('exit', () => {
       appProcess.kill()

--- a/packages/easy-framework/src/api.ts
+++ b/packages/easy-framework/src/api.ts
@@ -55,7 +55,15 @@ export class OuterApi extends Router {
         const hash = maybeHash(ctx.params.id)
         ctx.assert(hash, 400)
         const opt = await this.state.result.get(hash!)
-        if (opt.isSome() && (await this.blockchain.height) >= opt.value.height + 1) {
+        if (opt.isSome() && (400 <= opt.value.response.status && opt.value.response.status < 600)) {
+          const res = opt.value.response
+          ctx.response.status = res.status
+          ctx.response.message = res.message
+          for (const [key, value] of res.headers.list) {
+            ctx.response.append(key, value)
+          }
+          ctx.response.body = res.body
+        } else if (opt.isSome() && (await this.blockchain.height) >= opt.value.height + 1) {
           const res = opt.value.response
           ctx.response.status = res.status
           ctx.response.message = res.message

--- a/packages/event-provider/ethereum/scripts/run-test.ts
+++ b/packages/event-provider/ethereum/scripts/run-test.ts
@@ -1,8 +1,8 @@
 import childProcess from 'child_process'
 
-const ganache = childProcess.spawn('ganache-cli', ['--gasLimit', '8000000', '--port', '6545'])
+const ganache = childProcess.spawn('ganache-cli', ['--gasLimit', '8000000', '--port', '6545'], { shell: true })
 
-const test = childProcess.spawn('truffle', ['test', '--network', 'test'])
+const test = childProcess.spawn('truffle', ['test', '--network', 'test'], { shell: true })
 test.stdout.pipe(process.stdout)
 test.stderr.pipe(process.stderr)
 test.on('exit', (code) => {


### PR DESCRIPTION
## Bug Fix
Use the `shell` option of `childProcess.spawn` for Windows environments.
It is due to the specification of Node.js for Windows.
https://nodejs.org/docs/latest-v10.x/api/child_process.html#child_process_default_windows_shell

## Chore
Support building on Windows Native.
The setting of Azure Pipelines is also updated.